### PR TITLE
Feat: Zod schema first router

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,9 @@
 # Ignore artifacts:
 build
 coverage
+node_modules
+dist
+*.log
+package-lock.json
+yarn.lock
+bun.lock

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,1 +1,5 @@
-{}
+{
+  "tabWidth": 2,
+  "endOfLine": "lf",
+  "bracketSpacing": true
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["prettier.prettier-vscode"]
+  "recommendations": ["esbenp.prettier-vscode"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,24 +1,24 @@
 {
-  "editor.defaultFormatter": "prettier.prettier-vscode",
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.formatOnSaveMode": "file",
   "[javascript]": {
-    "editor.defaultFormatter": "prettier.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[typescript]": {
-    "editor.defaultFormatter": "prettier.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[typescriptreact]": {
-    "editor.defaultFormatter": "prettier.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[json]": {
-    "editor.defaultFormatter": "prettier.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[jsonc]": {
-    "editor.defaultFormatter": "prettier.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[markdown]": {
-    "editor.defaultFormatter": "prettier.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "eslint.format.enable": false,
   "prettier.requireConfig": true,

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "dev": "tsx watch ./src/index.ts --host 0.0.0.0",
     "build": "node build.mjs",
     "start": "set NODE_ENV=production && node ./dist/index.js",
-    "drizzle-studio": "npx drizzle-kit studio --port=3000",
     "cli": "tsx ./src/scripts/index.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "better-auth-generate": "npx @better-auth/cli generate --config ./src/lib/auth/index.ts --output ./src/schema/auth.ts",
+    "auth:generate": "npx @better-auth/cli generate --config ./src/lib/auth/index.ts --output ./src/schema/auth.ts",
+    "db:studio": "npx drizzle-kit studio --port=3000",
     "prepare": "husky"
   },
   "keywords": [],

--- a/src/lib/turbo-express/lib/error.ts
+++ b/src/lib/turbo-express/lib/error.ts
@@ -1,0 +1,10 @@
+export class AppError extends Error {
+  constructor(
+    public message: string,
+    public statusCode: number = 500,
+    public data?: Record<string, any>,
+  ) {
+    super(message);
+    this.name = "AppError";
+  }
+}

--- a/src/lib/turbo-express/router.core.ts
+++ b/src/lib/turbo-express/router.core.ts
@@ -1,0 +1,505 @@
+import { ZodObject, ZodRawShape, z, ZodError } from "zod";
+import {
+  Request,
+  Response,
+  NextFunction,
+  Router,
+  RequestHandler,
+  Application,
+} from "express";
+import { AppError } from "src/utils/error";
+
+/**
+ * Extended Request type that includes validated data
+ * This maintains Express's Request interface while adding validated property
+ */
+export interface ZodRequest<T extends ZodObject<ZodRawShape>> extends Request {
+  validated: z.infer<T>;
+}
+
+/**
+ * Route handler with automatic type inference from Zod schema
+ */
+type ZodRouteHandler<T extends ZodObject<ZodRawShape>> = (
+  req: ZodRequest<T>,
+  res: Response,
+  next: NextFunction,
+) => void | Promise<void> | Promise<any>;
+
+/**
+ * Configuration for validation behavior
+ */
+interface ValidationConfig {
+  /**
+   * Custom error handler for validation failures
+   */
+  onValidationError?: (error: ZodError, req: Request, res: Response) => any;
+  /**
+   * Include full error details in response
+   */
+  includeErrorDetails?: boolean;
+  /**
+   * Log validation errors
+   */
+  logErrors?: boolean;
+}
+
+/**
+ * Options for route registration
+ */
+interface RouteOptions {
+  /**
+   * Validation configuration for this route
+   */
+  validation?: ValidationConfig;
+  /**
+   * Additional middleware to run before the handler
+   */
+  middleware?: RequestHandler[];
+}
+
+/**
+ * Middleware that validates request against Zod schema
+ * and attaches validated data to req.validated
+ */
+const createZodValidationMiddleware = <T extends ZodObject<ZodRawShape>>(
+  schema: T,
+  handler: ZodRouteHandler<T>,
+  config: ValidationConfig = {},
+): RequestHandler => {
+  const {
+    onValidationError,
+    includeErrorDetails = true,
+    logErrors = true,
+  } = config;
+
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      // Validate the request
+      const parsed = schema.safeParse({
+        body: req.body,
+        query: req.query,
+        params: req.params,
+        headers: req.headers,
+      });
+
+      if (!parsed.success) {
+        // Custom error handler
+        if (onValidationError) {
+          const customResponse = onValidationError(parsed.error, req, res);
+          if (customResponse) {
+            return res.status(400).json(customResponse);
+          }
+        }
+
+        // Default error response
+        const errorResponse: any = {
+          message: "Validation failed",
+          errors: parsed.error.issues.map((err) => ({
+            path: err.path.join("."),
+            message: err.message,
+            code: err.code,
+          })),
+        };
+
+        // Include full schema for development
+        if (includeErrorDetails) {
+          errorResponse.schema = schema.toJSONSchema({
+            target: "openapi-3.0",
+            unrepresentable: "any",
+          } as any);
+        }
+
+        if (logErrors) {
+          console.warn("Validation Error:", {
+            path: req.path,
+            method: req.method,
+            errors: parsed.error.issues,
+          });
+        }
+
+        return res.status(400).json(errorResponse);
+      }
+
+      // Attach validated data to request
+      (req as any).validated = parsed.data;
+
+      // Execute the handler
+      const result = await handler(req as ZodRequest<T>, res, next);
+
+      return result;
+    } catch (error) {
+      // Don't override response if headers already sent
+      if (res.headersSent) {
+        return next(error);
+      }
+
+      // Handle AppError
+      if (error instanceof AppError) {
+        return res.status(error.statusCode).json({
+          message: error.message,
+          ...(error.data && { data: error.data }),
+        });
+      }
+
+      // Log unexpected errors
+      if (logErrors) {
+        console.error("Route Handler Error:", {
+          error: error instanceof Error ? error.message : String(error),
+          path: req.path,
+          method: req.method,
+          stack: error instanceof Error ? error.stack : undefined,
+        });
+      }
+
+      // Return generic error
+      return res.status(500).json({
+        message: "Internal Server Error",
+      });
+    }
+  };
+};
+
+/**
+ * Enhanced Express Route with Zod support
+ * Extends Express's Route class to add type-safe methods
+ */
+class ZodEnhancedRoute {
+  private route: any;
+  private defaultConfig: RouteOptions = {};
+
+  constructor(route: any) {
+    this.route = route;
+  }
+
+  /**
+   * Set default validation config for all methods on this route
+   */
+  setValidationConfig(config: ValidationConfig): this {
+    this.defaultConfig.validation = config;
+    return this;
+  }
+
+  /**
+   * Set default middleware for all methods on this route
+   */
+  setMiddleware(...middleware: RequestHandler[]): this {
+    this.defaultConfig.middleware = middleware;
+    return this;
+  }
+
+  /**
+   * Handle GET request with Zod validation
+   */
+  get<T extends ZodObject<ZodRawShape>>(
+    schema: T,
+    handler: ZodRouteHandler<T>,
+    options?: RouteOptions,
+  ): this {
+    const config = { ...this.defaultConfig, ...options };
+    const middleware = createZodValidationMiddleware(
+      schema,
+      handler,
+      config.validation,
+    );
+
+    if (config.middleware && config.middleware.length > 0) {
+      this.route.get(...config.middleware, middleware);
+    } else {
+      this.route.get(middleware);
+    }
+
+    return this;
+  }
+
+  /**
+   * Handle POST request with Zod validation
+   */
+  post<T extends ZodObject<ZodRawShape>>(
+    schema: T,
+    handler: ZodRouteHandler<T>,
+    options?: RouteOptions,
+  ): this {
+    const config = { ...this.defaultConfig, ...options };
+    const middleware = createZodValidationMiddleware(
+      schema,
+      handler,
+      config.validation,
+    );
+
+    if (config.middleware && config.middleware.length > 0) {
+      this.route.post(...config.middleware, middleware);
+    } else {
+      this.route.post(middleware);
+    }
+
+    return this;
+  }
+
+  /**
+   * Handle PUT request with Zod validation
+   */
+  put<T extends ZodObject<ZodRawShape>>(
+    schema: T,
+    handler: ZodRouteHandler<T>,
+    options?: RouteOptions,
+  ): this {
+    const config = { ...this.defaultConfig, ...options };
+    const middleware = createZodValidationMiddleware(
+      schema,
+      handler,
+      config.validation,
+    );
+
+    if (config.middleware && config.middleware.length > 0) {
+      this.route.put(...config.middleware, middleware);
+    } else {
+      this.route.put(middleware);
+    }
+
+    return this;
+  }
+
+  /**
+   * Handle PATCH request with Zod validation
+   */
+  patch<T extends ZodObject<ZodRawShape>>(
+    schema: T,
+    handler: ZodRouteHandler<T>,
+    options?: RouteOptions,
+  ): this {
+    const config = { ...this.defaultConfig, ...options };
+    const middleware = createZodValidationMiddleware(
+      schema,
+      handler,
+      config.validation,
+    );
+
+    if (config.middleware && config.middleware.length > 0) {
+      this.route.patch(...config.middleware, middleware);
+    } else {
+      this.route.patch(middleware);
+    }
+
+    return this;
+  }
+
+  /**
+   * Handle DELETE request with Zod validation
+   */
+  delete<T extends ZodObject<ZodRawShape>>(
+    schema: T,
+    handler: ZodRouteHandler<T>,
+    options?: RouteOptions,
+  ): this {
+    const config = { ...this.defaultConfig, ...options };
+    const middleware = createZodValidationMiddleware(
+      schema,
+      handler,
+      config.validation,
+    );
+
+    if (config.middleware && config.middleware.length > 0) {
+      this.route.delete(...config.middleware, middleware);
+    } else {
+      this.route.delete(middleware);
+    }
+
+    return this;
+  }
+
+  /**
+   * Handle HEAD request with Zod validation
+   */
+  head<T extends ZodObject<ZodRawShape>>(
+    schema: T,
+    handler: ZodRouteHandler<T>,
+    options?: RouteOptions,
+  ): this {
+    const config = { ...this.defaultConfig, ...options };
+    const middleware = createZodValidationMiddleware(
+      schema,
+      handler,
+      config.validation,
+    );
+
+    if (config.middleware && config.middleware.length > 0) {
+      this.route.head(...config.middleware, middleware);
+    } else {
+      this.route.head(middleware);
+    }
+
+    return this;
+  }
+
+  /**
+   * Handle OPTIONS request with Zod validation
+   */
+  options<T extends ZodObject<ZodRawShape>>(
+    schema: T,
+    handler: ZodRouteHandler<T>,
+    options?: RouteOptions,
+  ): this {
+    const config = { ...this.defaultConfig, ...options };
+    const middleware = createZodValidationMiddleware(
+      schema,
+      handler,
+      config.validation,
+    );
+
+    if (config.middleware && config.middleware.length > 0) {
+      this.route.options(...config.middleware, middleware);
+    } else {
+      this.route.options(middleware);
+    }
+
+    return this;
+  }
+
+  /**
+   * Access the underlying Express route for native methods
+   */
+  native(): any {
+    return this.route;
+  }
+}
+
+/**
+ * Enhanced Express Router with Zod support
+ * Extends Express Router while maintaining all native functionality
+ */
+class ZodRouter {
+  private router: Router;
+  private globalValidationConfig: ValidationConfig = {};
+  private globalMiddleware: RequestHandler[] = [];
+
+  constructor(router: Router = Router()) {
+    this.router = router;
+  }
+
+  /**
+   * Set global validation configuration for all routes
+   */
+  setGlobalValidationConfig(config: ValidationConfig): this {
+    this.globalValidationConfig = config;
+    return this;
+  }
+
+  /**
+   * Add global middleware to all routes
+   */
+  useGlobal(...middleware: RequestHandler[]): this {
+    this.globalMiddleware.push(...middleware);
+    this.router.use(...middleware);
+    return this;
+  }
+
+  /**
+   * Use standard Express middleware
+   */
+  use(...args: any[]): this {
+    this.router.use(...args);
+    return this;
+  }
+
+  /**
+   * Create a new route with Zod support
+   */
+  route(path: string): ZodEnhancedRoute {
+    const route = this.router.route(path);
+    const zodRoute = new ZodEnhancedRoute(route);
+    zodRoute.setValidationConfig(this.globalValidationConfig);
+
+    if (this.globalMiddleware.length > 0) {
+      zodRoute.setMiddleware(...this.globalMiddleware);
+    }
+
+    return zodRoute;
+  }
+
+  /**
+   * Access native Express router methods
+   */
+  native(): Router {
+    return this.router;
+  }
+
+  /**
+   * Get the underlying Express router
+   */
+  getRouter(): Router {
+    return this.router;
+  }
+
+  /**
+   * Proxy for standard Express router methods (get, post, etc)
+   */
+  all(path: string, ...args: any[]): this {
+    this.router.all(path, ...args);
+    return this;
+  }
+
+  get(path: string, ...args: any[]): this {
+    this.router.get(path, ...args);
+    return this;
+  }
+
+  post(path: string, ...args: any[]): this {
+    this.router.post(path, ...args);
+    return this;
+  }
+
+  put(path: string, ...args: any[]): this {
+    this.router.put(path, ...args);
+    return this;
+  }
+
+  patch(path: string, ...args: any[]): this {
+    this.router.patch(path, ...args);
+    return this;
+  }
+
+  delete(path: string, ...args: any[]): this {
+    this.router.delete(path, ...args);
+    return this;
+  }
+
+  head(path: string, ...args: any[]): this {
+    this.router.head(path, ...args);
+    return this;
+  }
+
+  options(path: string, ...args: any[]): this {
+    this.router.options(path, ...args);
+    return this;
+  }
+
+  /**
+   * Register this router with an Express app
+   */
+  registerWith(app: Application, basePath: string = ""): void {
+    app.use(basePath, this.router);
+  }
+}
+
+/**
+ * Factory function to create a Zod-enabled Express Router
+ */
+export const createZodRouter = (options?: {
+  validationConfig?: ValidationConfig;
+  globalMiddleware?: RequestHandler[];
+}): ZodRouter => {
+  const router = new ZodRouter();
+
+  if (options?.validationConfig) {
+    router.setGlobalValidationConfig(options.validationConfig);
+  }
+
+  if (options?.globalMiddleware && options.globalMiddleware.length > 0) {
+    router.useGlobal(...options.globalMiddleware);
+  }
+
+  return router;
+};
+
+export type { ZodRouteHandler, ValidationConfig, RouteOptions };

--- a/src/lib/turbo-express/router/README.md
+++ b/src/lib/turbo-express/router/README.md
@@ -1,0 +1,396 @@
+# Zod-Express Router - Design Philosophy & Taste
+
+## Core Design Principle
+
+**"Express plus schema, not a schema-first framework"**
+
+We extend Express's native patterns without introducing new abstractions or magical behavior. Everything should feel familiar to Express developers while adding optional Zod validation at the routing layer.
+
+---
+
+## Design Choices (Explained)
+
+### 1. Schema is Optional & Explicit
+
+```typescript
+// Don't need validation? Don't write schema
+router.get("/health", handler);
+
+// Need validation? Add schema
+router.schema(schema).get("/users", handler);
+```
+
+**Why:** Validation is a choice, not mandatory. Follows Express philosophy of "only pay for what you use."
+
+---
+
+### 2. Schema Sticks Within a Chain
+
+```typescript
+// Schema sticks to subsequent methods in same chain
+router
+  .schema(userSchema)
+  .get("/users", listHandler) // uses userSchema
+  .post("/users", createHandler) // uses userSchema
+  .put("/users/:id", updateHandler) // uses userSchema
+  .schema(adminSchema) // new schema replaces
+  .delete("/users/:id", deleteHandler); // uses adminSchema
+
+// New chain, schema resets
+router.get("/health", handler); // no schema
+```
+
+**Why:**
+
+- DRY - reuse schema across related methods naturally
+- Elegant - reads like prose "for users schema, do these three things"
+- Flexible - can override with new schema anytime
+- Functional - state is scoped to the chain, not the router instance
+
+---
+
+### 3. Methods Return `this` for Builder Pattern
+
+```typescript
+// Each method returns the same builder instance
+router
+  .schema(schema)
+  .get("/users", h1) // returns router
+  .post("/users", h2) // same router, continues chain
+  .put("/users/:id", h3); // same router, continues chain
+```
+
+**Why:**
+
+- Fluent chaining is natural and readable
+- State management is clear (schema sticks in this builder)
+- Stateful builder is more intuitive than functional pipeline
+- Matches how Express router works
+
+---
+
+### 4. Native Express Middleware Pattern
+
+```typescript
+// Middleware goes directly after path, just like Express
+router.schema(schema).get("/users", middleware1, middleware2, handler);
+
+// Compare to Express style:
+// router.get("/users", middleware1, middleware2, handler)
+```
+
+**Why:**
+
+- No new patterns to learn
+- Express developers immediately understand it
+- Middleware is Express's native feature, don't reinvent
+- Natural to how HTTP requests flow (middlewares run in order)
+
+---
+
+### 5. Path is Native Express Behavior
+
+```typescript
+// Both work, just like Express
+router.get(handler); // default path "/"
+router.get("/users", handler); // explicit path
+router.schema(schema).get("/path", handler);
+
+// No path grouping (like Express Router.route() handles this)
+```
+
+**Why:**
+
+- Express already handles path matching elegantly
+- Adding path grouping adds abstraction we don't need
+- Keep schema concerns separate from path concerns
+- Explicit path on each method is clearer
+
+---
+
+### 6. Single Validation Layer - Just Schema
+
+```typescript
+// Schema validates: body, query, params, headers
+const schema = z.object({
+  body: z.object({
+    /* ... */
+  }),
+  query: z.object({
+    /* ... */
+  }),
+  params: z.object({
+    /* ... */
+  }),
+  headers: z
+    .object({
+      /* ... */
+    })
+    .passthrough(),
+});
+
+router.schema(schema).post("/users/:id", handler);
+```
+
+**Why:**
+
+- Zod is powerful enough for all validation needs
+- No need for explicit param helpers
+- Single source of truth for validation
+- Conditional/custom validation via Zod's `.superRefine()`
+
+---
+
+### 7. Global Middleware via `.use()`
+
+```typescript
+// Native Express middleware - no schema involvement
+router.use(cors());
+router.use(express.json());
+router.use(authMiddleware);
+
+// Schema is separate concern
+router.schema(schema).get("/protected", handler);
+```
+
+**Why:**
+
+- Express already has `.use()` for global middleware
+- Middleware and validation are different concerns
+- Don't mix them
+- Schema is per-route, not global
+
+---
+
+## The Complete Picture
+
+### Request Flow
+
+```
+HTTP Request
+    ↓
+Global Middleware (.use())
+    ↓
+Route Match
+    ↓
+Per-Route Middleware (in .get()/.post() etc)
+    ↓
+Schema Validation (if schema defined)
+    ↓
+Handler Execution
+    ↓
+Response
+```
+
+### API Surface
+
+```typescript
+// Creation
+const router = createZodRouter(options?)
+
+// Global middleware (native Express)
+router.use(middleware)
+
+// Routes without validation
+router.get("/path", middleware?, handler)
+router.post("/path", middleware?, handler)
+// ... all HTTP methods
+
+// Routes with validation (schema sticks)
+router
+  .schema(schema)
+  .get("/path", middleware?, handler)
+  .post("/path", middleware?, handler)
+  .put("/path", middleware?, handler)
+  .delete("/path", middleware?, handler)
+
+// New schema breaks the chain
+router
+  .schema(newSchema)
+  .patch("/path", handler)
+
+// Registration with Express
+app.use("/api", router.getRouter())
+```
+
+---
+
+## Design Principles (Why We Made These Choices)
+
+### 1. **Minimal Abstraction**
+
+Don't create concepts Express doesn't have. Middleware is middleware, routing is routing, validation is validation.
+
+### 2. **Optional by Default**
+
+Schema is opt-in. If you don't need validation, don't write it. No forced empty schemas.
+
+### 3. **Express-Idiomatic**
+
+Every pattern should feel natural to Express developers. No special syntax or learning curve beyond Zod itself.
+
+### 4. **Explicit Over Implicit**
+
+Seeing `router.schema()` immediately tells you "this route is validated." Magic is the enemy.
+
+### 5. **Composition Over Configuration**
+
+Chain methods to build behavior. Don't create config objects.
+
+### 6. **Stateful Builder Within Scope**
+
+Schema sticks within a chain to avoid DRY violations. But state resets with new chains or new schema calls.
+
+### 7. **Single Responsibility**
+
+- Schema validates input
+- Middleware handles cross-cutting concerns
+- Router handles routing
+- Don't blur these lines
+
+---
+
+## Taste Philosophy
+
+### What This ISN'T
+
+❌ A framework - it's an extension of Express
+❌ Magic - everything is explicit
+❌ Opinionated about structure - you decide app organization
+❌ A wrapper that hides Express - everything underneath still works
+❌ Dependency injection or anything fancy - just routing + validation
+
+### What This IS
+
+✅ A natural extension of Express
+✅ Zod validation at the routing layer
+✅ Optional by design
+✅ Familiar to Express developers
+✅ Composable with native Express
+✅ Minimal, focused, do one thing well
+
+### The Aesthetic
+
+**Clean.** Lines of code should read like intent.
+
+```typescript
+router
+  .schema(userSchema) // "validate against userSchema"
+  .get("/users", listHandler) // "GET /users → listHandler"
+  .post("/users", createHandler); // "POST /users → createHandler"
+```
+
+No noise. No boilerplate. Just routing + validation.
+
+---
+
+## Key Decisions Summary
+
+| Aspect                 | Choice           | Why                             |
+| ---------------------- | ---------------- | ------------------------------- |
+| Schema Optional        | Yes              | Not all routes need validation  |
+| Schema Sticks          | Yes, in chain    | DRY, natural reuse              |
+| Builder Returns `this` | Yes              | Fluent, stateful, intuitive     |
+| Middleware Pattern     | Native Express   | No new patterns                 |
+| Path Handling          | Express style    | No abstraction needed           |
+| Param Validation       | Via schema       | Single validation layer         |
+| Global Middleware      | Via `.use()`     | Already how Express works       |
+| Validation Location    | Per-route schema | Clear, explicit, testable       |
+| Configuration          | Fluent API       | Composition, not config objects |
+
+---
+
+## Example: The Complete Taste
+
+```typescript
+import express from "express";
+import { z } from "zod";
+import { createZodRouter } from "./zod-express-router";
+
+const app = express();
+app.use(express.json());
+
+// Create router
+const router = createZodRouter();
+
+// Define schemas
+const userSchema = z.object({
+  body: z.object({
+    email: z.string().email(),
+    name: z.string().min(2),
+  }),
+});
+
+const userDetailSchema = z.object({
+  params: z.object({
+    id: z.string().cuid(),
+  }),
+});
+
+// Global middleware (native Express)
+router.use((req, res, next) => {
+  req.id = generateId();
+  next();
+});
+
+// Routes with schema - schema sticks
+router
+  .schema(userSchema)
+  .get("/users", listUsers) // no schema needed for GET list
+  .post("/users", createUser); // validates body
+
+// Oops, need different schema for detail routes
+// Break the chain with new schema
+router
+  .schema(userDetailSchema)
+  .get("/users/:id", getUser) // validates params
+  .put("/users/:id", updateUser) // validates params
+  .delete("/users/:id", deleteUser); // validates params
+
+// Route with no validation - no schema call needed
+router.get("/health", (req, res) => {
+  res.json({ status: "ok" });
+});
+
+// Register with app
+app.use("/api", router.getRouter());
+
+// Everything still works with Express
+app.use((err, req, res, next) => {
+  console.error(err);
+  res.status(500).json({ error: "Server error" });
+});
+
+app.listen(3000);
+```
+
+**This reads like:**
+
+- "For users data, schema validates body"
+- "GET /users endpoint, no schema (list doesn't validate)"
+- "POST /users endpoint, validates body"
+- "For user details, schema validates params"
+- "GET/PUT/DELETE /users/:id, all validate params"
+- "Health check, no validation"
+
+**No magic. No framework. Just Express + Zod.**
+
+---
+
+## Implementation Guideline
+
+When building this, keep asking:
+
+**"Does an Express developer immediately understand this without docs?"**
+
+If not, simplify.
+
+**"Is this doing something Express already does?"**
+
+If yes, use Express's way.
+
+**"Does this add value?"**
+
+If not, remove it.
+
+This is the taste. This is the philosophy.

--- a/src/lib/turbo-express/router/core.ts
+++ b/src/lib/turbo-express/router/core.ts
@@ -1,0 +1,619 @@
+import { ZodObject, ZodRawShape, z, ZodError } from "zod";
+import {
+  Request,
+  Response,
+  NextFunction,
+  Router,
+  RequestHandler,
+  Application,
+} from "express";
+
+/**
+ * Extended Request type with validated data
+ * This is what gets passed to route handlers
+ */
+export interface ZodRequest<
+  T extends ZodObject<ZodRawShape> = ZodObject<ZodRawShape>,
+> extends Request {
+  validated: z.infer<T>;
+}
+
+/**
+ * Route handler with full type inference
+ */
+export type ZodRouteHandler<T extends ZodObject<ZodRawShape>> = (
+  req: ZodRequest<T>,
+  res: Response,
+  next?: NextFunction,
+) => void | Promise<void> | Promise<any>;
+
+/**
+ * Validation configuration
+ */
+export interface ValidationConfig {
+  onValidationError?: (error: ZodError, req: Request, res: Response) => any;
+  includeErrorDetails?: boolean;
+  logErrors?: boolean;
+}
+
+/**
+ * Creates validation middleware with full type safety
+ */
+const createValidationMiddleware = <T extends ZodObject<ZodRawShape>>(
+  schema: T,
+  handler: ZodRouteHandler<T>,
+  config: ValidationConfig = {},
+): RequestHandler => {
+  const {
+    onValidationError,
+    includeErrorDetails = true,
+    logErrors = true,
+  } = config;
+
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const parsed = schema.safeParse({
+        body: req.body,
+        query: req.query,
+        params: req.params,
+        headers: req.headers,
+      });
+
+      if (!parsed.success) {
+        if (onValidationError) {
+          const customResponse = onValidationError(parsed.error, req, res);
+          if (customResponse) {
+            return res.status(400).json(customResponse);
+          }
+        }
+
+        // Fix: Use parsed.error.issues instead of parsed.error.errors
+        const errorResponse: any = {
+          message: "Validation failed",
+          errors: parsed.error.issues.map((issue: any) => ({
+            path: issue.path.join("."),
+            message: issue.message,
+            code: issue.code,
+          })),
+        };
+
+        if (includeErrorDetails) {
+          try {
+            errorResponse.schema = schema.toJSONSchema({
+              target: "openapi-3.0",
+              unrepresentable: "any",
+            } as any);
+          } catch {
+            // Schema conversion might fail
+          }
+        }
+
+        if (logErrors) {
+          console.warn("Validation Error:", {
+            path: req.path,
+            method: req.method,
+            timestamp: new Date().toISOString(),
+          });
+        }
+
+        return res.status(400).json(errorResponse);
+      }
+
+      (req as any).validated = parsed.data;
+
+      const result = await handler(req as ZodRequest<T>, res, next);
+      return result;
+    } catch (error: unknown) {
+      // Fix: Properly type the error parameter
+      if (res.headersSent) {
+        return next(error as Error);
+      }
+
+      if (logErrors) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        console.error("Route Handler Error:", {
+          error: errorMessage,
+          path: req.path,
+          method: req.method,
+        });
+      }
+
+      return res.status(500).json({
+        message: "Internal Server Error",
+      });
+    }
+  };
+};
+
+/**
+ * ZodRoute builder with proper type inference for each method
+ * This class handles the chaining logic and maintains schema state
+ */
+class ZodRoute {
+  private route: any;
+  private currentSchema?: ZodObject<ZodRawShape>;
+  private validationConfig: ValidationConfig;
+
+  constructor(route: any, validationConfig: ValidationConfig = {}) {
+    this.route = route;
+    this.validationConfig = validationConfig;
+  }
+
+  /**
+   * Set schema and return typed builder
+   * The return type ensures proper inference in the chain
+   */
+  schema<T extends ZodObject<ZodRawShape>>(
+    schemaParam: T,
+  ): ZodRouteWithSchema<T> {
+    this.currentSchema = schemaParam;
+    return new ZodRouteWithSchema(
+      this.route,
+      schemaParam,
+      this.validationConfig,
+    );
+  }
+
+  /**
+   * Without schema - route methods available but no validation
+   */
+  get(path: string, handler: RequestHandler): this;
+  get(path: string, middleware: RequestHandler, handler: RequestHandler): this;
+  get(path: string, ...args: any[]): this {
+    this._addRoute("get", path, args);
+    return this;
+  }
+
+  post(path: string, handler: RequestHandler): this;
+  post(path: string, middleware: RequestHandler, handler: RequestHandler): this;
+  post(path: string, ...args: any[]): this {
+    this._addRoute("post", path, args);
+    return this;
+  }
+
+  put(path: string, handler: RequestHandler): this;
+  put(path: string, middleware: RequestHandler, handler: RequestHandler): this;
+  put(path: string, ...args: any[]): this {
+    this._addRoute("put", path, args);
+    return this;
+  }
+
+  patch(path: string, handler: RequestHandler): this;
+  patch(
+    path: string,
+    middleware: RequestHandler,
+    handler: RequestHandler,
+  ): this;
+  patch(path: string, ...args: any[]): this {
+    this._addRoute("patch", path, args);
+    return this;
+  }
+
+  delete(path: string, handler: RequestHandler): this;
+  delete(
+    path: string,
+    middleware: RequestHandler,
+    handler: RequestHandler,
+  ): this;
+  delete(path: string, ...args: any[]): this {
+    this._addRoute("delete", path, args);
+    return this;
+  }
+
+  head(path: string, handler: RequestHandler): this;
+  head(path: string, middleware: RequestHandler, handler: RequestHandler): this;
+  head(path: string, ...args: any[]): this {
+    this._addRoute("head", path, args);
+    return this;
+  }
+
+  options(path: string, handler: RequestHandler): this;
+  options(
+    path: string,
+    middleware: RequestHandler,
+    handler: RequestHandler,
+  ): this;
+  options(path: string, ...args: any[]): this {
+    this._addRoute("options", path, args);
+    return this;
+  }
+
+  private _addRoute(method: string, path: string, args: any[]): void {
+    const handler = args[args.length - 1] as RequestHandler;
+    const middlewares = args.slice(0, -1) as RequestHandler[];
+
+    const allMiddlewares: RequestHandler[] = [...middlewares];
+
+    if (this.currentSchema) {
+      const validationMiddleware = createValidationMiddleware(
+        this.currentSchema,
+        handler as any,
+        this.validationConfig,
+      );
+      allMiddlewares.push(validationMiddleware);
+    } else {
+      allMiddlewares.push(handler);
+    }
+
+    (this.route as any)[method](path, ...allMiddlewares);
+  }
+
+  native(): any {
+    return this.route;
+  }
+}
+
+/**
+ * ZodRouteWithSchema - Builder with schema context
+ * This class provides FULLY TYPED route methods based on the schema
+ */
+class ZodRouteWithSchema<T extends ZodObject<ZodRawShape>> {
+  private route: any;
+  private currentSchema: T;
+  private validationConfig: ValidationConfig;
+
+  constructor(
+    route: any,
+    schemaParam: T,
+    validationConfig: ValidationConfig = {},
+  ) {
+    this.route = route;
+    this.currentSchema = schemaParam;
+    this.validationConfig = validationConfig;
+  }
+
+  /**
+   * Change schema and return new builder
+   * Breaks the current chain
+   */
+  schema<T2 extends ZodObject<ZodRawShape>>(
+    schemaParam: T2,
+  ): ZodRouteWithSchema<T2> {
+    return new ZodRouteWithSchema(
+      this.route,
+      schemaParam,
+      this.validationConfig,
+    );
+  }
+
+  /**
+   * GET with full type inference from schema
+   * req, res, and req.validated are all properly typed
+   */
+  get(path: string, handler: ZodRouteHandler<T>): this;
+  get(
+    path: string,
+    middleware: RequestHandler,
+    handler: ZodRouteHandler<T>,
+  ): this;
+  get(
+    path: string,
+    middleware: RequestHandler,
+    middleware2: RequestHandler,
+    handler: ZodRouteHandler<T>,
+  ): this;
+  get(path: string, ...args: any[]): this {
+    this._addRoute("get", path, args);
+    return this;
+  }
+
+  /**
+   * POST with full type inference from schema
+   */
+  post(path: string, handler: ZodRouteHandler<T>): this;
+  post(
+    path: string,
+    middleware: RequestHandler,
+    handler: ZodRouteHandler<T>,
+  ): this;
+  post(
+    path: string,
+    middleware: RequestHandler,
+    middleware2: RequestHandler,
+    handler: ZodRouteHandler<T>,
+  ): this;
+  post(path: string, ...args: any[]): this {
+    this._addRoute("post", path, args);
+    return this;
+  }
+
+  /**
+   * PUT with full type inference from schema
+   */
+  put(path: string, handler: ZodRouteHandler<T>): this;
+  put(
+    path: string,
+    middleware: RequestHandler,
+    handler: ZodRouteHandler<T>,
+  ): this;
+  put(
+    path: string,
+    middleware: RequestHandler,
+    middleware2: RequestHandler,
+    handler: ZodRouteHandler<T>,
+  ): this;
+  put(path: string, ...args: any[]): this {
+    this._addRoute("put", path, args);
+    return this;
+  }
+
+  /**
+   * PATCH with full type inference from schema
+   */
+  patch(path: string, handler: ZodRouteHandler<T>): this;
+  patch(
+    path: string,
+    middleware: RequestHandler,
+    handler: ZodRouteHandler<T>,
+  ): this;
+  patch(
+    path: string,
+    middleware: RequestHandler,
+    middleware2: RequestHandler,
+    handler: ZodRouteHandler<T>,
+  ): this;
+  patch(path: string, ...args: any[]): this {
+    this._addRoute("patch", path, args);
+    return this;
+  }
+
+  /**
+   * DELETE with full type inference from schema
+   */
+  delete(path: string, handler: ZodRouteHandler<T>): this;
+  delete(
+    path: string,
+    middleware: RequestHandler,
+    handler: ZodRouteHandler<T>,
+  ): this;
+  delete(
+    path: string,
+    middleware: RequestHandler,
+    middleware2: RequestHandler,
+    handler: ZodRouteHandler<T>,
+  ): this;
+  delete(path: string, ...args: any[]): this {
+    this._addRoute("delete", path, args);
+    return this;
+  }
+
+  /**
+   * HEAD with full type inference from schema
+   */
+  head(path: string, handler: ZodRouteHandler<T>): this;
+  head(
+    path: string,
+    middleware: RequestHandler,
+    handler: ZodRouteHandler<T>,
+  ): this;
+  head(
+    path: string,
+    middleware: RequestHandler,
+    middleware2: RequestHandler,
+    handler: ZodRouteHandler<T>,
+  ): this;
+  head(path: string, ...args: any[]): this {
+    this._addRoute("head", path, args);
+    return this;
+  }
+
+  /**
+   * OPTIONS with full type inference from schema
+   */
+  options(path: string, handler: ZodRouteHandler<T>): this;
+  options(
+    path: string,
+    middleware: RequestHandler,
+    handler: ZodRouteHandler<T>,
+  ): this;
+  options(
+    path: string,
+    middleware: RequestHandler,
+    middleware2: RequestHandler,
+    handler: ZodRouteHandler<T>,
+  ): this;
+  options(path: string, ...args: any[]): this {
+    this._addRoute("options", path, args);
+    return this;
+  }
+
+  private _addRoute(method: string, path: string, args: any[]): void {
+    const handler = args[args.length - 1] as ZodRouteHandler<T>;
+    const middlewares = args.slice(0, -1) as RequestHandler[];
+
+    const allMiddlewares: RequestHandler[] = [...middlewares];
+
+    const validationMiddleware = createValidationMiddleware(
+      this.currentSchema,
+      handler,
+      this.validationConfig,
+    );
+    allMiddlewares.push(validationMiddleware);
+
+    (this.route as any)[method](path, ...allMiddlewares);
+  }
+
+  native(): any {
+    return this.route;
+  }
+}
+
+/**
+ * ZodRouter - Main class for creating routers with Zod validation
+ * Provides full TypeScript support with schema-based type inference
+ */
+export class ZodRouter {
+  private router: Router;
+  private validationConfig: ValidationConfig;
+
+  constructor(
+    router: Router = Router(),
+    validationConfig: ValidationConfig = {},
+  ) {
+    this.router = router;
+    this.validationConfig = validationConfig;
+  }
+
+  /**
+   * Set schema and get typed builder
+   */
+  schema<T extends ZodObject<ZodRawShape>>(
+    schemaParam: T,
+  ): ZodRouteWithSchema<T> {
+    return new ZodRouteWithSchema(
+      this.router,
+      schemaParam,
+      this.validationConfig,
+    );
+  }
+
+  /**
+   * Native Express .use() for global middleware
+   */
+  use(...args: any[]): this {
+    this.router.use(...args);
+    return this;
+  }
+
+  /**
+   * GET without schema
+   */
+  get(path: string, handler: RequestHandler): this;
+  get(path: string, middleware: RequestHandler, handler: RequestHandler): this;
+  get(path: string, ...args: any[]): this {
+    const handler = args[args.length - 1] as RequestHandler;
+    const middlewares = args.slice(0, -1) as RequestHandler[];
+    this.router.get(path, ...middlewares, handler);
+    return this;
+  }
+
+  /**
+   * POST without schema
+   */
+  post(path: string, handler: RequestHandler): this;
+  post(path: string, middleware: RequestHandler, handler: RequestHandler): this;
+  post(path: string, ...args: any[]): this {
+    const handler = args[args.length - 1] as RequestHandler;
+    const middlewares = args.slice(0, -1) as RequestHandler[];
+    this.router.post(path, ...middlewares, handler);
+    return this;
+  }
+
+  /**
+   * PUT without schema
+   */
+  put(path: string, handler: RequestHandler): this;
+  put(path: string, middleware: RequestHandler, handler: RequestHandler): this;
+  put(path: string, ...args: any[]): this {
+    const handler = args[args.length - 1] as RequestHandler;
+    const middlewares = args.slice(0, -1) as RequestHandler[];
+    this.router.put(path, ...middlewares, handler);
+    return this;
+  }
+
+  /**
+   * PATCH without schema
+   */
+  patch(path: string, handler: RequestHandler): this;
+  patch(
+    path: string,
+    middleware: RequestHandler,
+    handler: RequestHandler,
+  ): this;
+  patch(path: string, ...args: any[]): this {
+    const handler = args[args.length - 1] as RequestHandler;
+    const middlewares = args.slice(0, -1) as RequestHandler[];
+    this.router.patch(path, ...middlewares, handler);
+    return this;
+  }
+
+  /**
+   * DELETE without schema
+   */
+  delete(path: string, handler: RequestHandler): this;
+  delete(
+    path: string,
+    middleware: RequestHandler,
+    handler: RequestHandler,
+  ): this;
+  delete(path: string, ...args: any[]): this {
+    const handler = args[args.length - 1] as RequestHandler;
+    const middlewares = args.slice(0, -1) as RequestHandler[];
+    this.router.delete(path, ...middlewares, handler);
+    return this;
+  }
+
+  /**
+   * HEAD without schema
+   */
+  head(path: string, handler: RequestHandler): this;
+  head(path: string, middleware: RequestHandler, handler: RequestHandler): this;
+  head(path: string, ...args: any[]): this {
+    const handler = args[args.length - 1] as RequestHandler;
+    const middlewares = args.slice(0, -1) as RequestHandler[];
+    this.router.head(path, ...middlewares, handler);
+    return this;
+  }
+
+  /**
+   * OPTIONS without schema
+   */
+  options(path: string, handler: RequestHandler): this;
+  options(
+    path: string,
+    middleware: RequestHandler,
+    handler: RequestHandler,
+  ): this;
+  options(path: string, ...args: any[]): this {
+    const handler = args[args.length - 1] as RequestHandler;
+    const middlewares = args.slice(0, -1) as RequestHandler[];
+    this.router.options(path, ...middlewares, handler);
+    return this;
+  }
+
+  /**
+   * ALL methods
+   */
+  all(path: string, handler: RequestHandler): this;
+  all(path: string, middleware: RequestHandler, handler: RequestHandler): this;
+  all(path: string, ...args: any[]): this {
+    const handler = args[args.length - 1] as RequestHandler;
+    const middlewares = args.slice(0, -1) as RequestHandler[];
+    this.router.all(path, ...middlewares, handler);
+    return this;
+  }
+
+  /**
+   * Get native Express Router
+   */
+  getRouter(): Router {
+    return this.router;
+  }
+
+  /**
+   * Register with Express app
+   */
+  registerWith(app: Application, basePath: string = ""): void {
+    app.use(basePath, this.router);
+  }
+}
+
+/**
+ * Factory to create ZodRouter
+ */
+export const createZodRouter = (options?: {
+  validationConfig?: ValidationConfig;
+}): ZodRouter => {
+  return new ZodRouter(Router(), options?.validationConfig);
+};
+
+/**
+ * Enhance existing Express router with Zod support
+ */
+export const enhanceRouter = (
+  expressRouter: Router,
+  validationConfig?: ValidationConfig,
+): ZodRouter => {
+  return new ZodRouter(expressRouter, validationConfig);
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,6 +3,7 @@ import { Environment } from "../utils/environment";
 import { apiReference } from "@scalar/express-api-reference";
 import staticRouter from "./static";
 import api from "./api";
+import testRouter from "./test";
 
 const router = express.Router();
 
@@ -31,5 +32,7 @@ router.get("/health", async (req, res) => {
 });
 
 /* your routes here */
+
+router.use("/test", testRouter.getRouter());
 
 export default router;

--- a/src/routes/test.ts
+++ b/src/routes/test.ts
@@ -1,0 +1,37 @@
+import { createZodRouter } from "src/lib/turbo-express/router/core";
+import z from "zod";
+
+const testRouter = createZodRouter();
+
+testRouter
+  .schema(
+    z.object({
+      query: z.object({
+        name: z.string().optional(),
+        age: z.coerce.number().optional(),
+      }),
+    }),
+  )
+  .get("", async (req, res) => {
+    const { name, age } = req.validated.query;
+    return res.json({
+      message: `Hello, ${name || "world"}! You are ${age || "unknown"} years old.`,
+    });
+  })
+  .schema(
+    z.object({
+      query: z.object({
+        name: z.string().optional(),
+        age: z.coerce.number().optional(),
+        address: z.string().optional(),
+      }),
+    }),
+  )
+  .get("/address", async (req, res) => {
+    const { name, age, address } = req.validated.query;
+    return res.json({
+      message: `Hello, ${name || "world"}! You are ${age || "unknown"} years old. Your address is ${address || "unknown"}.`,
+    });
+  });
+
+export default testRouter;


### PR DESCRIPTION
NOTE: We still have much more clean up to do on the router part. That is currently just generated with AI.

This pull request introduces improvements to code formatting consistency, developer tooling, and adds a new example router demonstrating schema validation with Zod in Express. The most important changes are grouped as follows:

**Formatting and Tooling Improvements**

* Updated `.prettierrc` to specify formatting rules for code consistency, including `tabWidth`, `endOfLine`, and `bracketSpacing`.
* Expanded `.prettierignore` to exclude common build artifacts and lock files, reducing unnecessary formatting of generated files.
* Changed VSCode formatter settings and extension recommendations to use the canonical Prettier extension (`esbenp.prettier-vscode`) for improved developer experience. [[1]](diffhunk://#diff-c16655a98a3ee89a7636a59c59a72b0e93649e3a1e947327cfc43a1336b4e912L2-R2) [[2]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L2-R21)

**Turbo-Express Library Enhancements**

* Added `AppError` class to `src/lib/turbo-express/lib/error.ts` for standardized error handling in Express applications.
* Added a comprehensive design philosophy document for the Zod-Express router, clarifying its principles and usage patterns for developers.

**New Example Router and Route Registration**

* Added `testRouter` in `src/routes/test.ts` as an example of schema-based validation with Zod, including two endpoints demonstrating query parameter validation and chaining schemas.
* Registered `testRouter` under `/test` in the main router, making the new endpoints available in the application. [[1]](diffhunk://#diff-4c1a276a826a5147689418cdbf9bde24c8326cedb30a61144fe7867bd99113efR6) [[2]](diffhunk://#diff-4c1a276a826a5147689418cdbf9bde24c8326cedb30a61144fe7867bd99113efR36-R37)

**Script and Command Improvements**

* Renamed and reorganized scripts in `package.json` for clarity and consistency, including changing `better-auth-generate` to `auth:generate` and `drizzle-studio` to `db:studio`.
